### PR TITLE
Save config in user's home, not root directory

### DIFF
--- a/metadata/storage.go
+++ b/metadata/storage.go
@@ -28,7 +28,8 @@ func getPlatformStoragePath(filename string) string {
 		cache, _ := os.UserCacheDir()
 		return filepath.Join(cache, windowsDir, filename)
 	default:
-		return filepath.Join(linuxDir, filename)
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, linuxDir, filename)
 	}
 }
 


### PR DESCRIPTION
The default case for the getPlatformStoragePath tries to use `/.config/Sampler` on Linux and other Unixes, rather than `$HOME/.config/Sampler` as it should.

I had to temporarily comment out the code related to the [alsa issue](https://github.com/sqshq/sampler/issues/2), but after doing so I was able to run on Linux (only tested on Ubuntu) and confirm this does write to the correct directory now.

    chris@<REDACTED>:~/.config/Sampler$ pwd
    /home/chris/.config/Sampler
    chris@<REDACTED>:~/.config/Sampler$ ls -al
    total 0
    drwxrwxrwx 1 chris chris 4096 Aug  2 22:12 .
    drwx------ 1 chris chris 4096 Aug  2 22:12 ..
    -rwxrwxrwx 1 chris chris  157 Aug  2 22:12 statistics.yml

I didn't see any tests, so I didn't add any for this. If I overlooked them please point me at the right location and I'll add a new one or update whatever is there to cover this case.