### PR TITLE
Cleanup escape codes for regular and interactive shell sampling

### DIFF
--- a/data/int_basic.go
+++ b/data/int_basic.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"github.com/lunixbochs/vtclean"
 	"io"
 	"os/exec"
 	"strings"
@@ -118,7 +119,7 @@ func (s *BasicInteractiveShell) execute() (string, error) {
 			if errorText.Len() > 0 {
 				return "", errors.New(errorText.String())
 			}
-			return s.item.transform(resultText.String())
+			return s.item.transform(vtclean.Clean(resultText.String(), false))
 		}
 	}
 }

--- a/data/item.go
+++ b/data/item.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	ui "github.com/gizak/termui/v3"
+	"github.com/lunixbochs/vtclean"
 	"github.com/sqshq/sampler/config"
 	"os"
 	"os/exec"
@@ -70,7 +71,9 @@ func (i *Item) execute(variables []string, script string) (string, error) {
 		return "", err
 	}
 
-	return string(output), nil
+	o := string(output)
+
+	return vtclean.Clean(o, false), nil
 }
 
 func (i *Item) initInteractiveShell(v []string) error {


### PR DESCRIPTION
Fixes unreadable text for #47 
Support for colors might be implemented later.