### PR TITLE
Add Fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ sudo wget https://github.com/sqshq/sampler/releases/download/v1.0.3/sampler-1.0.
 sudo chmod +x /usr/local/bin/sampler
 ```
 Note: `libasound2-dev` system library is required to be installed for Sampler to play a [trigger](https://github.com/sqshq/sampler#triggers) sound tone. Usually the library is in place, but if not - you can install it with your favorite package manager, e.g `apt install libasound2-dev`
+#### Packaging status
+- [Fedora](https://apps.fedoraproject.org/packages/sampler) `sudo dnf install sampler` (F31+)
 ### Windows (experimental)
 Recommended to use with advanced console emulators, e.g. [Cmder](https://cmder.net/)
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sudo chmod +x /usr/local/bin/sampler
 ```
 Note: `libasound2-dev` system library is required to be installed for Sampler to play a [trigger](https://github.com/sqshq/sampler#triggers) sound tone. Usually the library is in place, but if not - you can install it with your favorite package manager, e.g `apt install libasound2-dev`
 #### Packaging status
-- [Fedora](https://apps.fedoraproject.org/packages/sampler) `sudo dnf install sampler` (F31+)
+- [Fedora](https://apps.fedoraproject.org/packages/golang-github-sqshq-sampler) `sudo dnf install golang-github-sqshq-sampler` (F31+)
 ### Windows (experimental)
 Recommended to use with advanced console emulators, e.g. [Cmder](https://cmder.net/)
 


### PR DESCRIPTION
Packaged for Fedora and now in official repos. Now on [QA](https://bodhi.fedoraproject.org/updates/FEDORA-2019-28e1174269). Please add installation info on main page.