### PR TITLE
Expand the number of available gradients (for sparklines) from 2 to 40.

### DIFF
--- a/component/sparkline/sparkline.go
+++ b/component/sparkline/sparkline.go
@@ -19,21 +19,23 @@ type SparkLine struct {
 	maxValue float64
 	minValue float64
 	scale    int
-	gradient []ui.Color
 	palette  console.Palette
 	mutex    *sync.Mutex
+	color       ui.Color
 }
 
 func NewSparkLine(c config.SparkLineConfig, palette console.Palette) *SparkLine {
-
+	// fmt.Printf("%+v\n", c.Item)
+	// os.Exit(0)
 	line := &SparkLine{
 		Block:    component.NewBlock(c.Title, true, palette),
 		Consumer: data.NewConsumer(),
 		values:   []float64{},
 		scale:    *c.Scale,
-		gradient: *c.Gradient,
 		palette:  palette,
 		mutex:    &sync.Mutex{},
+		color:       *c.Item.Color,
+
 	}
 
 	go func() {
@@ -125,7 +127,8 @@ func (s *SparkLine) Draw(buffer *ui.Buffer) {
 		}
 
 		for j := 0; j <= top; j++ {
-			buffer.SetCell(ui.NewCell(console.SymbolVerticalBar, ui.NewStyle(console.GetGradientColor(s.gradient, j, height))), image.Pt(s.Inner.Max.X-n-indent, s.Inner.Max.Y-j-1))
+			col := console.GetGradientColor(s.color, j, height)
+			buffer.SetCell(ui.NewCell(console.SymbolVerticalBar, ui.NewStyle(col)), image.Pt(s.Inner.Max.X-n-indent, s.Inner.Max.Y-j-1))
 		}
 
 		if i == len(s.values)-1 {

--- a/config/component.go
+++ b/config/component.go
@@ -71,7 +71,6 @@ type SparkLineConfig struct {
 	ComponentConfig `yaml:",inline"`
 	Scale           *int        `yaml:"scale,omitempty"`
 	Item            Item        `yaml:",inline"`
-	Gradient        *[]ui.Color `yaml:",omitempty"`
 }
 
 type BarChartConfig struct {

--- a/config/default.go
+++ b/config/default.go
@@ -205,9 +205,12 @@ func (c *Config) setDefaultItemSettings() {
 	}
 
 	for i, s := range c.SparkLines {
-		s.Gradient = &palette.GradientColors[i%(len(palette.GradientColors))]
 		if s.Item.Pty == nil {
 			s.Item.Pty = &defaultPty
+		}
+
+		if s.Item.Color == nil {
+			s.Item.Color = &palette.ContentColors[i%colorsCount]
 		}
 		c.SparkLines[i] = s
 	}

--- a/console/palette.go
+++ b/console/palette.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"fmt"
+	"math"
 	"runtime"
 
 	ui "github.com/gizak/termui/v3"
@@ -12,6 +13,10 @@ type Theme string
 const (
 	ThemeDark  Theme = "dark"
 	ThemeLight Theme = "light"
+)
+
+const (
+	GradientCount    ui.Color = 6  // How many colors in a gradient
 )
 
 const (
@@ -53,7 +58,6 @@ func GetPalette(theme Theme) Palette {
 	case ThemeDark:
 		return Palette{
 			ContentColors:  []ui.Color{ColorOlive, ColorDeepSkyBlue, ColorDeepPink, ColorWhite, ColorGrey, ColorGreen, ColorOrange, ColorCian, ColorPurple},
-			GradientColors: [][]ui.Color{{39, 33, 62, 93, 164, 161}, {95, 138, 180, 179, 178, 178}},
 			BaseColor:      ColorWhite,
 			MediumColor:    ColorDarkGrey,
 			ReverseColor:   ColorBlack,
@@ -93,11 +97,26 @@ func GetMenuColorReverse() ui.Color {
 	}
 }
 
-func GetGradientColor(gradient []ui.Color, cur int, max int) ui.Color {
-	ratio := float64(len(gradient)) / float64(max)
-	index := int(ratio * float64(cur))
-	if index > len(gradient)-1 {
-		index = len(gradient) - 1
+// GetGradientColor returns a color based on an input color
+// and two cur, max values. The function tries to find a range
+// of 6 (GradientCount) colors that look similar but are in a
+// gradient. It divids the colorspace from color 16 to 255 in
+// 40 sections consisting of 6 colors each.
+// If the input color is in the 0-15 range it is mapped to it's
+// equivalent in the upper (16-255) range.
+func GetGradientColor(color ui.Color, cur int, max int) ui.Color {
+	// Remap lower 16 colors to higher values that are equivalent
+	if color < 16 {
+		ColorMap := [16]ui.Color {16, 88, 34, 208, 19, 53, 30, 250, 244, 196, 46, 226, 21, 201, 51, 255}
+		color = ColorMap[color]
 	}
-	return gradient[index]
+
+	// Find the lowest id in the range for the gradient
+	// selected by color
+	baseColor := ui.Color(((color-16) / GradientCount) * GradientCount + 16)
+
+	// Calculate the offset in the range starting from baseColor
+	offset := int(math.Min(float64(6) / float64(max) * float64(cur), 6))
+
+	return baseColor + ui.Color(offset)
 }

--- a/console/palette_test.go
+++ b/console/palette_test.go
@@ -48,52 +48,84 @@ func TestGetPaletteInvalidTheme(t *testing.T) {
 }
 
 func TestGetGradientColor(t *testing.T) {
-	type args struct {
-		gradient []ui.Color
+	type testArgs struct {
+		color    ui.Color
 		cur      int
 		max      int
+		want     ui.Color
 	}
 
-	var (
-		lightThemeGradientInput = args{
-			gradient: []ui.Color{
-				250, 248, 246, 244, 242, 240, 238, 236, 234, 232, 16,
-			},
-			cur: 200,
-			max: 250,
-		}
-
-		darkThemeGradientInput = args{
-			gradient: []ui.Color{
-				39, 33, 62, 93, 164, 161,
-			},
-			cur: 40,
-			max: 180,
-		}
-
-		grey ui.Color = 234
-
-		blue ui.Color = 33
-	)
-
-	tests := []struct {
-		name string
-		args
-		want ui.Color
-	}{
-		{"should return color grey", lightThemeGradientInput, grey},
-		{"should return color blue", darkThemeGradientInput, blue},
+	var tests = []testArgs{
+		{
+			color: 2,
+			cur: 55,
+			max: 60,
+			want: 39,
+		},
+		{
+			color: 6,
+			cur: 12,
+			max: 60,
+			want: 29,
+		},
+		{
+			color: 233,
+			cur: 19,
+			max: 60,
+			want: 233,
+		},
+		{
+			color: 109,
+			cur: 8,
+			max: 60,
+			want: 106,
+		},
+		{
+			color: 14,
+			cur: 34,
+			max: 60,
+			want: 49,
+		},
+		{
+			color: 201,
+			cur: 10,
+			max: 20,
+			want: 199,
+		},
+		{
+			color: 201,
+			cur: 15,
+			max: 30,
+			want: 199,
+		},
+		{
+			color: 201,
+			cur: 82,
+			max: 260,
+			want: 197,
+		},
+		{
+			color: 201,
+			cur: 9388,
+			max: 100032,
+			want: 196,
+		},
+		{
+			color: 201,
+			cur: 2,
+			max: 302,
+			want: 196,
+		},
 	}
 
-	for _, test := range tests {
+	for i := 0; i<len(tests); i++ {
 		gradientColor := GetGradientColor(
-			test.gradient,
-			test.cur,
-			test.max,
+			tests[i].color,
+			tests[i].cur,
+			tests[i].max,
 		)
-
-		if got := gradientColor; got != test.want {
-			t.Errorf("GetGradientColor(%v) = %d, want %d", test.args, got, test.want)
+		if got := gradientColor; got != tests[i].want {
+			t.Errorf("GetGradientColor(%d, %d, %d) = %d, want %d", tests[i].color, tests[i].cur, tests[i].max, got, tests[i].want)
 		}
 	}
 }


### PR DESCRIPTION
This is my first ever code I've written in GO, so comments and suggestions are very welcome.

This change adds the ability to set color on sparklines. To create a gradient for a specific color the colorspace is divided up in groups of 6 similar colors.

I've also updated the test.