### PR TITLE
Cast rateMs when calculating NewTicker duration to avoid overflow on RPI

### DIFF
--- a/data/sampler.go
+++ b/data/sampler.go
@@ -17,7 +17,7 @@ type Sampler struct {
 
 func NewSampler(consumer *Consumer, items []*Item, triggers []*Trigger, options config.Options, fileVariables map[string]string, rateMs int) *Sampler {
 
-	ticker := time.NewTicker(time.Duration(rateMs * int(time.Millisecond)))
+	ticker := time.NewTicker(time.Duration(uint32(rateMs) * uint32(time.Millisecond)))
 
 	sampler := &Sampler{
 		consumer,


### PR DESCRIPTION
Explicitly cast value for time.Duration to uint32 to avoid overflow on Raspberry PI. 

Tested on an RPI3B+
```Linux raspberrypi 4.19.75-v7+ #1270 SMP Tue Sep 24 18:45:11 BST 2019 armv7l GNU/Linux```
```Raspbian GNU/Linux 10 \n \l```

Fixes #70 