### PR TITLE
Fix go.mod for go 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/sqshq/sampler
 
+go 1.17
+
 require (
 	github.com/gizak/termui/v3 v3.0.0
 	github.com/hajimehoshi/go-mp3 v0.1.1
@@ -9,7 +11,16 @@ require (
 	github.com/lunixbochs/vtclean v1.0.0
 	github.com/mattn/go-runewidth v0.0.4
 	github.com/mbndr/figlet4go v0.0.0-20190224160619-d6cef5b186ea
-	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20190709130402-674ba3eaed22
+)
+
+require (
+	github.com/cjbassi/drawille-go v0.0.0-20190126131713-27dc511fe6fd // indirect
+	github.com/gopherjs/gopherjs v0.0.0-20180628210949-0892b62f0d9f // indirect
+	github.com/gopherjs/gopherwasm v0.1.1 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d // indirect
+	golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045 // indirect
+	gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 // indirect
 )


### PR DESCRIPTION
Currently, if you run go mod vendor - this command rewrites the go.mod file since it doesn't fully enumerate the dependencies. This breaks some of the infrastructure which autoamtically builds this code (i.e. nixos).