### PR TITLE
Replace deps kr/pty with creak/pty to fix crash on macOs

### DIFF
--- a/data/int_pty.go
+++ b/data/int_pty.go
@@ -1,16 +1,18 @@
-//+build !windows
+//go:build !windows
+// +build !windows
 
 package data
 
 import (
 	"bufio"
 	"fmt"
-	"github.com/kr/pty"
-	"github.com/lunixbochs/vtclean"
 	"io"
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/creack/pty"
+	"github.com/lunixbochs/vtclean"
 )
 
 // PtyInteractiveShell represents PTY interactive shell sampling metadata

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/hajimehoshi/go-mp3 v0.1.1
 	github.com/hajimehoshi/oto v0.1.1
 	github.com/jessevdk/go-flags v1.4.0
-	github.com/kr/pty v1.1.5
 	github.com/lunixbochs/vtclean v1.0.0
 	github.com/mattn/go-runewidth v0.0.4
 	github.com/mbndr/figlet4go v0.0.0-20190224160619-d6cef5b186ea
@@ -16,6 +15,7 @@ require (
 
 require (
 	github.com/cjbassi/drawille-go v0.0.0-20190126131713-27dc511fe6fd // indirect
+	github.com/creack/pty v1.1.21 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20180628210949-0892b62f0d9f // indirect
 	github.com/gopherjs/gopherwasm v0.1.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/cjbassi/drawille-go v0.0.0-20190126131713-27dc511fe6fd h1:XtfPmj9tQRilnrEmI1HjQhxXWRhEM+m8CACtaMJE/kM=
 github.com/cjbassi/drawille-go v0.0.0-20190126131713-27dc511fe6fd/go.mod h1:vjcQJUZJYD3MeVGhtZXSMnCHfUNZxsyYzJt90eCYxK4=
+github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
+github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/gizak/termui/v3 v3.0.0 h1:NYTUG6ig/sJK05O5FyhWemwlVPO8ilNpvS/PgRtrKAE=
 github.com/gizak/termui/v3 v3.0.0/go.mod h1:uinu2dMdtMI+FTIdEFUJQT5y+KShnhQRshvPblXq3lY=
 github.com/gopherjs/gopherjs v0.0.0-20180628210949-0892b62f0d9f h1:FDM3EtwZLyhW48YRiyqjivNlNZjAObv4xt4NnJaU+NQ=


### PR DESCRIPTION
Attempted fix for '_Setctty set but Ctty not valid in child_' when using ssh and pty:true on macOS.

The issue was discussed here https://github.com/creack/pty/issues/96; sampler was using an older fork kr/pty, the issue doesn't seem to be present with the latest creak/pty.

fix #110